### PR TITLE
fix: loading via module

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
-  /@esbuild-kit/esm-loader/2.5.1:
-    resolution: {integrity: sha512-UfG/KLaNGR48+C9e8cDrRowhN9u+d/aCKpnA3E3Zyevup76fIpKmzm8DWeNG40CbEN8ZN8HaEs+o63pRQrZ+Fw==}
+  /@esbuild-kit/esm-loader/2.5.2:
+    resolution: {integrity: sha512-8mF/cPFFvaO/yyzQPwlB+rMqCVw6S5X+MlVquvniUslwFSU5s2QXZhg3BAqndUKbIL7k1eMutVyMc9TCDRHSpw==}
     dependencies:
       '@esbuild-kit/core-utils': 3.0.0
       get-tsconfig: 4.2.0
@@ -3233,7 +3233,7 @@ packages:
     dependencies:
       '@esbuild-kit/cjs-loader': 2.4.1
       '@esbuild-kit/core-utils': 3.0.0
-      '@esbuild-kit/esm-loader': 2.5.1
+      '@esbuild-kit/esm-loader': 2.5.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,12 +58,12 @@ export const createFsRequire = (
 	const fsRequireId = idCounter;
 	const moduleCache: ModuleCache = Object.create(null);
 
-	function makeRequireFunction(parentModule: Module): fsRequire {
+	function makeRequireFunction(parentModule?: Module | null): fsRequire {
 		const resolve = (modulePath: string) => {
 			if (isBareSpecifier(modulePath)) {
 				return modulePath;
 			}
-			const resolved = resolveModule(mfs, parentModule, modulePath);
+			const resolved = resolveModule(mfs, modulePath, parentModule);
 			return resolved.filePath;
 		};
 
@@ -72,13 +72,13 @@ export const createFsRequire = (
 				return resolveBareSpecifier(mfs, modulePath, options);
 			}
 
-			const resolvedPath = resolveModule(mfs, parentModule, modulePath);
+			const resolvedPath = resolveModule(mfs, modulePath, parentModule);
 			const { filePath } = resolvedPath;
 
 			let importedModule = moduleCache[filePath];
 
 			if (!importedModule) {
-				importedModule = new Module(filePath, parentModule);
+				importedModule = new Module(filePath, parentModule || undefined);
 				importedModule.filename = filePath;
 
 				const sourceCode = mfs.readFileSync(filePath).toString();
@@ -103,6 +103,5 @@ export const createFsRequire = (
 		return require;
 	}
 
-	// @ts-expect-error parent is deprecated
-	return makeRequireFunction(module.parent);
+	return makeRequireFunction(typeof module === 'undefined' ? undefined : module.parent);
 };

--- a/src/utils/resolve-module.ts
+++ b/src/utils/resolve-module.ts
@@ -17,18 +17,20 @@ type Resolved = {
 
 function resolveModuleSafe(
 	mfs: FileSystemLike,
-	parentModule: Module,
 	modulePath: string,
+	parentModule?: Module | null,
 ): Resolved | null {
 	// Absolute path
-	modulePath = path.resolve(path.dirname(parentModule.filename), modulePath);
+	if (!path.isAbsolute(modulePath) && parentModule) {
+		modulePath = path.resolve(path.dirname(parentModule.filename), modulePath);
+	}
 
 	// Exact match
 	if (mfs.existsSync(modulePath)) {
 		if (isDirectory(mfs, modulePath)) {
 			return (
-				resolveModuleSafe(mfs, parentModule, path.join(modulePath, 'index.js'))
-				|| resolveModuleSafe(mfs, parentModule, path.join(modulePath, 'index.json'))
+				resolveModuleSafe(mfs, path.join(modulePath, 'index.js'), parentModule)
+				|| resolveModuleSafe(mfs, path.join(modulePath, 'index.json'), parentModule)
 			);
 		}
 
@@ -55,10 +57,10 @@ function resolveModuleSafe(
 
 export function resolveModule(
 	mfs: FileSystemLike,
-	parentModule: Module,
 	modulePath: string,
+	parentModule?: Module | null,
 ) {
-	const resolved = resolveModuleSafe(mfs, parentModule, modulePath);
+	const resolved = resolveModuleSafe(mfs, modulePath, parentModule);
 
 	if (!resolved) {
 		throw new Error(`Cannot find module '${modulePath}'`);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -3,4 +3,7 @@ import { describe } from 'manten';
 describe('fs-require', ({ runTestSuite }) => {
 	runTestSuite(import('./specs/fs-require.js'));
 	runTestSuite(import('./specs/resolve.js'));
+
+	// eslint-disable-next-line import/extensions
+	runTestSuite(import('./specs/module.mjs'));
 });

--- a/tests/specs/module.mts
+++ b/tests/specs/module.mts
@@ -1,0 +1,31 @@
+import { testSuite, expect } from 'manten';
+import { Volume } from 'memfs';
+import { createFsRequire } from '../../dist/index.mjs';
+
+export default testSuite(({ describe }) => {
+	describe('module', ({ test }) => {
+		test('Nested, relative, & absolute paths', () => {
+			const randomNumber = Math.random();
+			const vol = Volume.fromJSON({
+				'/root-file-d.js': `module.exports = function () { return ${randomNumber}; };`,
+				'/directory/nested/nested/file-c.js': 'module.exports = require(\'/root-file-d\')',
+				'/directory/file-b.js': 'module.exports = require(\'./nested/nested/file-c\')',
+				'/file-a.js': 'const fn = require(\'./directory/file-b\'); module.exports = fn();',
+				'/index.js': 'module.exports = require(\'./file-a\');',
+			});
+			const fsRequire = createFsRequire(vol);
+
+			expect(fsRequire('/index')).toBe(randomNumber);
+		});
+	});
+});
+
+// 			import { Volume } from 'memfs';
+// import { createFsRequire } from '../../dist/index.mjs';
+
+// const vol = Volume.fromJSON({
+// 	'/index.js': `module.exports = 123`,
+// });
+// const fsReq = createFsRequire(vol);
+
+// console.log(fsReq('/index'));

--- a/tests/specs/module.mts
+++ b/tests/specs/module.mts
@@ -19,13 +19,3 @@ export default testSuite(({ describe }) => {
 		});
 	});
 });
-
-// 			import { Volume } from 'memfs';
-// import { createFsRequire } from '../../dist/index.mjs';
-
-// const vol = Volume.fromJSON({
-// 	'/index.js': `module.exports = 123`,
-// });
-// const fsReq = createFsRequire(vol);
-
-// console.log(fsReq('/index'));

--- a/tests/specs/module.mts
+++ b/tests/specs/module.mts
@@ -1,6 +1,6 @@
 import { testSuite, expect } from 'manten';
 import { Volume } from 'memfs';
-import { createFsRequire } from '../../dist/index.mjs';
+import { createFsRequire } from '#fs-require';
 
 export default testSuite(({ describe }) => {
 	describe('module', ({ test }) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,5 @@
 		"isolatedModules": true,
 		"esModuleInterop": true,
 		"strict": true,
-
-		// Node 12
-		"target": "ES2019"
 	}
 }


### PR DESCRIPTION
When loading the CommonJS package via ESM, there is no `module.parent`, or `module` in full ESM mode.